### PR TITLE
ci: add ubuntu 20.04 to release matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,6 +72,7 @@ jobs:
         os:
           - ubuntu24.04
           - ubuntu22.04
+          - ubuntu20.04
           - debian13
           - debian12
           - debian11


### PR DESCRIPTION
Add `ubuntu20.04` to the Linux release build matrix so pre-built artifacts are produced for Ubuntu 20.04 as well.